### PR TITLE
docs: update README with absolute image URLs and optimize package dis…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="public/logo.svg" width="120" height="120" alt="Hyper Scheduler Logo">
+  <img src="https://github.com/CrazyMrYan/hyper-scheduler/raw/main/public/logo.svg" width="120" height="120" alt="Hyper Scheduler Logo">
 </p>
 
 <h1 align="center">Hyper Scheduler</h1>
@@ -21,7 +21,7 @@ A lightweight, dependency-free (core) JavaScript task scheduler supporting Cron 
 
 ## DevTools
 
-![](./public/task-list.png)
+![](https://github.com/CrazyMrYan/hyper-scheduler/raw/main/public/task-list.png)
 
 ## Quick Start
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyper-scheduler",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A lightweight, dependency-free (core) JavaScript task scheduler supporting Cron expressions and Web Workers.",
   "type": "module",
   "main": "./dist/index.umd.js",
@@ -15,8 +15,7 @@
   "files": [
     "dist",
     "README.md",
-    "LICENSE",
-    "public"
+    "LICENSE"
   ],
   "scripts": {
     "dev": "vite",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       filename: 'stats.html'
     }),
   ],
+  publicDir: false, // 禁用 public 目录的复制
   build: {
     lib: {
       entry: resolve(__dirname, 'src/index.ts'),


### PR DESCRIPTION
…tribution

- Update logo image URL to use absolute GitHub raw content URL for reliable CDN delivery
- Update task-list screenshot URL to use absolute GitHub raw content URL
- Bump version from 1.1.3 to 1.1.4
- Remove public directory from package.json files array to reduce distribution size
- Disable public directory copying in Vite config to prevent unnecessary assets in build output
- These changes ensure images display correctly in package registries and reduce npm package size