### PR TITLE
ci: update release workflow and bump version to 1.1.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,28 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**.md'
-      - '.githn: yarn install --frozen-lockfile
+      - '.github/**'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
       - name: Build
         run: yarn build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyper-scheduler",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "A lightweight, dependency-free (core) JavaScript task scheduler supporting Cron expressions and Web Workers.",
   "type": "module",
   "main": "./dist/index.umd.js",


### PR DESCRIPTION
- Fix paths-ignore configuration in release workflow to properly exclude .github directory
- Add complete release job definition with proper permissions and steps
- Configure Node.js 18 setup with npm registry authentication
- Add frozen lockfile installation step for dependency consistency
- Bump package version from 1.1.4 to 1.1.5
- Ensure workflow properly triggers on push to main branch excluding docs and markdown files