### PR TITLE
ci: update Node.js version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies


### PR DESCRIPTION
- Update Node.js version from 18 to 20 in release workflow
- Ensure compatibility with latest Node.js LTS version
- Improve build and deployment reliability with newer runtime