### PR TITLE
ci: remove .github path from release workflow ignore list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**.md'
-      - '.github/**'
 
 jobs:
   release:


### PR DESCRIPTION
- Remove .github/** from paths-ignore to trigger releases on workflow changes
- Allow release workflow updates to automatically trigger new releases
- Ensure workflow modifications are properly reflected in release process