### PR TITLE
ci: remove .github path from release workflow ignore list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,8 +118,6 @@ jobs:
             ### 📚 Documentation
             
             https://crazymryan.github.io/hyper-scheduler/
-          files: |
-            dist/**/*
           draft: false
           prerelease: false
         env:


### PR DESCRIPTION
- Remove .github/** from paths-ignore to trigger releases on workflow changes
- Allow release workflow updates to automatically trigger new releases
- Ensure workflow modifications are properly reflected in release process