### PR TITLE
ci(release): update npm publish workflow to handle 2FA requirement

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,14 +118,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish to npm
+      - name: Comment on npm publish
         if: steps.check_tag.outputs.exists == 'false' || (steps.check_tag.outputs.exists == 'true' && steps.check_release.outputs.exists == 'false')
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          echo "⚠️ npm 发布需要手动完成（因为启用了 2FA）"
+          echo "请在本地运行: npm publish --access public"
+          echo "或者在 npm 网站创建 Automation Token 并更新 GitHub Secrets 中的 NPM_TOKEN"
 
       - name: Publish to GitHub Packages
         if: steps.check_tag.outputs.exists == 'false' || (steps.check_tag.outputs.exists == 'true' && steps.check_release.outputs.exists == 'false')
+        continue-on-error: true
         run: |
           echo "@crazymryan:registry=https://npm.pkg.github.com" > .npmrc
           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyper-scheduler",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "A lightweight, dependency-free (core) JavaScript task scheduler supporting Cron expressions and Web Workers.",
   "type": "module",
   "main": "./dist/index.umd.js",


### PR DESCRIPTION
- Replace automated npm publish step with manual instruction comment
- Add warning message explaining 2FA requirement prevents automation
- Include instructions for local npm publish command
- Provide guidance for creating Automation Token as alternative
- Add continue-on-error flag to GitHub Packages publish step
- Improve workflow reliability by acknowledging 2FA security constraint